### PR TITLE
Fix config flow

### DIFF
--- a/custom_components/previous_state_tracker/config_flow.py
+++ b/custom_components/previous_state_tracker/config_flow.py
@@ -29,7 +29,7 @@ class PreviousStateTrackerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
-        return PreviousStateTrackerOptionsFlow(config_entry)
+        return PreviousStateTrackerOptionsFlow()
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> config_entries.FlowResult:
         if user_input is not None:

--- a/custom_components/previous_state_tracker/config_flow.py
+++ b/custom_components/previous_state_tracker/config_flow.py
@@ -82,9 +82,6 @@ class PreviousStateTrackerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class PreviousStateTrackerOptionsFlow(config_entries.OptionsFlow):
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self.config_entry = config_entry
-
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> config_entries.FlowResult:
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Previous State Tracker",
   "render_readme": true,
-  "homeassistant": "2024.7.0"
+  "homeassistant": "2024.12.0"
 }


### PR DESCRIPTION
Fixes #10 

Have to bump to a minimum HA version in HACS of 2024.12

Home Assistant 2024.12 changed to providing the config_entry and you should not be taking a copy of it.
https://developers.home-assistant.io/blog/2024/11/12/options-flow
